### PR TITLE
Add LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include AUTHORS
 include ChangeLog
+include LICENSE
 exclude .gitignore
 exclude .gitreview
 


### PR DESCRIPTION
Include LICENSE in MANIFEST.in so that we can include a hard-link to the license in [`meta.yaml` file](https://github.com/conda-forge/debtcollector-feedstock/blob/master/recipe/meta.yaml) in the [conda-forge feedstock](https://github.com/conda-forge/debtcollector-feedstock)
